### PR TITLE
Use global dimensionLabelPrefix for both static and discovery job

### DIFF
--- a/pkg/config.go
+++ b/pkg/config.go
@@ -14,9 +14,10 @@ const defaultLengthSeconds = int64(300)
 const defaultDelaySeconds = int64(300)
 
 type ScrapeConf struct {
-	ApiVersion string    `yaml:"apiVersion"`
-	Discovery  Discovery `yaml:"discovery"`
-	Static     []*Static `yaml:"static"`
+	ApiVersion           string    `yaml:"apiVersion"`
+	Discovery            Discovery `yaml:"discovery"`
+	Static               []*Static `yaml:"static"`
+	DimensionLabelPrefix *string   `yaml:"dimensionLabelPrefix"`
 }
 
 type Discovery struct {

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -71,7 +71,7 @@ func TestDimensionLabelField(t *testing.T) {
 			t.Error(err)
 			t.FailNow()
 		}
-		var keyPrefix *string = config.Discovery.DimensionLabelPrefix
+		var keyPrefix *string = config.DimensionLabelPrefix
 		if tc.presenceCheck {
 			if keyPrefix == nil {
 				t.Error("key 'dimensionLabelPrefix' was not parsed successfully.")

--- a/pkg/testdata/config_test.yml
+++ b/pkg/testdata/config_test.yml
@@ -1,6 +1,6 @@
 apiVersion: v1alpha1
+dimensionLabelPrefix: ""
 discovery:
-  dimensionLabelPrefix: ""
   exportedTagsOnMetrics:
     ebs:
       - VolumeId

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -22,7 +22,7 @@ func UpdateMetrics(
 	)
 	var metrics []*PrometheusMetric
 
-	metrics = append(metrics, migrateCloudwatchToPrometheus(cloudwatchData, labelsSnakeCase, config.Discovery.DimensionLabelPrefix)...)
+	metrics = append(metrics, migrateCloudwatchToPrometheus(cloudwatchData, labelsSnakeCase, config.DimensionLabelPrefix)...)
 	metrics = ensureLabelConsistencyForMetrics(metrics)
 
 	metrics = append(metrics, migrateTagsToPrometheus(tagsData, labelsSnakeCase)...)


### PR DESCRIPTION
Static jobs also require DimensionLabelPrefix override. This change allows a global override option to remove the `dimension_` prefix for all