### PR TITLE
No need to export 'dimension_' label when prefix is specified

### DIFF
--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -349,7 +349,6 @@ func createPrometheusLabels(cwd *cloudwatchData, labelsSnakeCase bool, dimension
 
 	// Inject the sfn name back as a label
 	for _, dimension := range cwd.Dimensions {
-		labels["dimension_"+promStringTag(*dimension.Name, labelsSnakeCase)] = *dimension.Value
 		if dimensionLabelPrefix != nil {
 			labels[*dimensionLabelPrefix+promStringTag(*dimension.Name, labelsSnakeCase)] = *dimension.Value
 		} else {


### PR DESCRIPTION
Seems this line was missed from your latest code merge. Fix this to match with https://github.com/yashsarma/yet-another-cloudwatch-exporter/blob/make-label-prefix-optional/pkg/aws_cloudwatch.go#L322-L328